### PR TITLE
Replace Thread.isAlive with Thread.is_alive

### DIFF
--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -735,7 +735,7 @@ class SpeedTest(Animation):
             speed_dl = 0
             while len(finished) < total_files:
                 thread = queue.get(True)
-                while thread.isAlive():
+                while thread.is_alive():
                     thread.join(timeout=0.1)
                 finished.append(sum(thread.result))
                 speed_f = ((sum(finished) / (timeit.default_timer() - start)) / 1000 / 1000) * 8
@@ -749,9 +749,9 @@ class SpeedTest(Animation):
         start = timeit.default_timer()
         prod_thread.start()
         cons_thread.start()
-        while prod_thread.isAlive():
+        while prod_thread.is_alive():
             prod_thread.join(timeout=0.1)
-        while cons_thread.isAlive():
+        while cons_thread.is_alive():
             cons_thread.join(timeout=0.1)
         return sum(finished) / (timeit.default_timer() - start)
 
@@ -772,7 +772,7 @@ class SpeedTest(Animation):
             speed_dl = 0
             while len(finished) < total_sizes:
                 thread = queue.get(True)
-                while thread.isAlive():
+                while thread.is_alive():
                     thread.join(timeout=0.1)
                 finished.append(thread.result)
                 speed_f = ((sum(finished) / (timeit.default_timer() - start)) / 1000 / 1000) * 8
@@ -786,9 +786,9 @@ class SpeedTest(Animation):
         start = timeit.default_timer()
         prod_thread.start()
         cons_thread.start()
-        while prod_thread.isAlive():
+        while prod_thread.is_alive():
             prod_thread.join(timeout=0.1)
-        while cons_thread.isAlive():
+        while cons_thread.is_alive():
             cons_thread.join(timeout=0.1)
         return sum(finished) / (timeit.default_timer() - start)
 


### PR DESCRIPTION
Thread.isAlive method has been deprecated in Python 3.8 and got removed
in 3.9 [1].

On some distributions like Arch Linux, Kodi is run with newest Python
(as for this day 3.9.3). As a result this addon is broken because of:

    ERROR <general>: AttributeError
    ERROR <general>: :
    ERROR <general>: 'FileGetter' object has no attribute 'isAlive'
    ERROR <general>:

This commit fixes the issue.
is_alive naming spelling has been already introduced in 2.6 [2] so
hopefully this change is safe for Kodi Leia.

[1]: https://bugs.python.org/issue37804
[2]: https://devdocs.io/python~2.7/library/threading#threading.Thread.is_alive